### PR TITLE
Add optional callback to start(), remove console.log

### DIFF
--- a/examples/EchoBot.coffee
+++ b/examples/EchoBot.coffee
@@ -8,4 +8,5 @@ tg.on 'message', (msg) ->
     reply_to_message_id: msg.message_id
     chat_id: msg.chat.id
 
-tg.start()
+tg.start (me) ->
+	console.log "#{me.first_name} running!"

--- a/src/telegram.coffee
+++ b/src/telegram.coffee
@@ -23,11 +23,11 @@ class Telegram extends EventEmitter
       id = _.last(data.result)?.update_id || update_id
       self.polling(id + 1)
 
-  start: ->
+  start: (callback) ->
     @getMe().then (data) =>
       @me = data.result
       @emit 'connected', @me
-      console.log @me
+      callback.call null, @me unless typeof callback isnt 'function'
       @polling()
 
 methods = """


### PR DESCRIPTION
Some people (myself included) may not want this console.log.
Instead, allowing the user to pass an optional callback to the start method seems better to me.
(He could also listen on the _connected_ event, but that's basically a shortcut)
